### PR TITLE
feat(postcomment): Add the functionality to post a comment to the associated PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,4 +11,5 @@ jobs:
         env:
           INTEGRATION_TEST: true
           INPUT_CODEOWNERS_PATH: ./__tests__/data/CODEOWNERS
-          GITHUB_TOKEN: "{{secrets.GITHUB_TOKEN}}"
+          GITHUB_TOKEN: '{{secrets.GITHUB_TOKEN}}'
+          INPUT_POST_COMMENT: true

--- a/__tests__/integration-test.test.ts
+++ b/__tests__/integration-test.test.ts
@@ -77,6 +77,14 @@ describe('integration-test', () => {
           patch: '',
         },
       ])
+      .post(
+        `/repos/${process.env.GITHUB_REPOSITORY}/issues/${github.context.payload.number}/comments`,
+        {
+          body:
+            'The following files do not have CODEOWNER\n- __tests__/integration-test.test.js',
+        }
+      )
+      .reply(200)
     expect.assertions(1)
     try {
       await main()

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -94,14 +94,14 @@ describe('index', () => {
     it('Should pass when all the files are covered', () => {
       const ig = ignore().add('file1').add('file2')
       return checkFiles(ig, ['file1', 'file2']).then((result) => {
-        expect(result).toBe(true)
+        expect(result).toEqual([])
       })
     })
 
     it('Should fail when not all the files are covered', () => {
       const ig = ignore().add('file1')
       return checkFiles(ig, ['file1', 'file2']).then((result) => {
-        expect(result).toBe(false)
+        expect(result).toEqual(['file2'])
       })
     })
   })

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,9 @@ inputs:
   CODEOWNERS_PATH:
     description: 'Location of the codeowner file.'
     default: '.github/CODEOWNERS'
+  POST_COMMENT:
+    description: 'Post a comment to the PR if the files changed do not have a code owner'
+    default: true
 runs:
   using: 'node12'
   main: 'index.js'

--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,11 @@ This action is to enforce codeowner for PR.
 The path to the CODEOWNERS file in this repository.
 The default value is `.github/CODEOWNERS`
 
+### POST_COMMENT
+
+Specify the value to be `true` if you want the github action to automatically post a comment to the associated PR when the changed files do not have code owner.
+The default value is `true`.
+
 ### Environment Variable
 
 The only `env` variable required is the token for the action to run: GitHub generates one automatically, but you need to pass it through `env` to make it available to actions. You can find more about `GITHUB_TOKEN` [here](https://help.github.com/en/articles/virtual-environments-for-github-actions#github_token-secret).
@@ -19,6 +24,7 @@ The only `env` variable required is the token for the action to run: GitHub gene
 uses: cuichenli/enforce-codeowner@
 with:
   CODEWONERS_PATH: '.github/CODEOWNERS'
+  POST_COMMENT: true
 env:
   GITHUB_TOKEN: '{{ secrets.GITHUB_TOKEN }}'
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,11 @@
 import * as core from '@actions/core'
 import * as github from '@actions/github/lib/github'
-import { checkFiles, readRequiredContext, generateIgnore } from './utils'
+import {
+  checkFiles,
+  readRequiredContext,
+  generateIgnore,
+  postComment,
+} from './utils'
 import process from 'process'
 import { OctokitResponse, PullsListFilesResponseData } from '@octokit/types'
 import ignore from 'ignore'
@@ -23,7 +28,8 @@ export async function main(): Promise<void> {
   generateIgnore(ig, codeOwnerPath)
   const diffFiles = response.data.map((data) => data.filename)
   const result = await checkFiles(ig, diffFiles)
-  if (!result) {
+  if (result.length !== 0) {
+    await postComment(result, owner, repo, prNumber, octokit)
     throw new Error('Test failed.')
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -69,13 +69,15 @@ export async function postComment(
   message.push('The following files do not have CODEOWNER')
   message.push(...fileList.map((file) => `- ${file}`))
   const body = message.join('\n')
-  await octokit.request(
-    'POST /repos/{owner}/{repo}/issues/{issue_number}/comments',
-    {
-      owner,
-      repo,
-      issue_number,
-      body,
-    }
-  )
+  if (core.getInput('POST_COMMENT').toLowerCase() === 'true') {
+    await octokit.request(
+      'POST /repos/{owner}/{repo}/issues/{issue_number}/comments',
+      {
+        owner,
+        repo,
+        issue_number,
+        body,
+      }
+    )
+  }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,8 +27,8 @@ export function generateIgnore(
 export async function checkFiles(
   ig: Ignore,
   diffFiles: string[]
-): Promise<boolean> {
-  let passed = true
+): Promise<string[]> {
+  const failedList: string[] = []
   diffFiles.forEach((file) => {
     // The ignore package is initially for gitignore, since the CODEOWNERS file
     // share the same syntax with gitignore, we can use this package to check
@@ -37,10 +37,10 @@ export async function checkFiles(
     core.info(`Checking file ${file}`)
     if (!ig.ignores(file)) {
       core.error(`${file} does not have a codeowner.`)
-      passed = false
+      failedList.push(file)
     }
   })
-  return passed
+  return failedList
 }
 
 export function readRequiredContext(): [string, number] {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,6 +2,7 @@ import fs from 'fs'
 import * as core from '@actions/core'
 import * as github from '@actions/github'
 import { Ignore } from 'ignore'
+import { GitHub } from '@actions/github/lib/utils'
 
 export function generateIgnore(
   ig: Ignore,
@@ -51,4 +52,30 @@ export function readRequiredContext(): [string, number] {
 
   const prNumber = github.context.payload.number
   return [token, Number(prNumber)]
+}
+
+export async function postComment(
+  fileList: string[],
+  owner: string,
+  repo: string,
+  prNumber: number,
+  octokit: InstanceType<typeof GitHub>
+): Promise<void> {
+  if (fileList.length === 0) {
+    return
+  }
+  const message: string[] = []
+  const issue_number = prNumber
+  message.push('The following files do not have CODEOWNER')
+  message.push(...fileList.map((file) => `- ${file}`))
+  const body = message.join('\n')
+  await octokit.request(
+    'POST /repos/{owner}/{repo}/issues/{issue_number}/comments',
+    {
+      owner,
+      repo,
+      issue_number,
+      body,
+    }
+  )
 }


### PR DESCRIPTION
Fixes #3 

Add a new input variable `POST_COMMENT`. If the value of it is `true` and the files changed in this PR do not have code owner, this GitHub action will post a comment to the PR to list files are not covered. 